### PR TITLE
Multi-domain support when using virtual domains

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014 Michael Bester
+Copyright (c) 2015 Nik Khilnani
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To install the No DB URL Shortener, take the following steps:
 
 * Upload this entire repository to the host on which you want this to live. It should work on the document root or in a subdirectory. Don't forget the `.htaccess` file. Alternatively, you can do clone this repository to the server where you want this to live.
 * In the `inc` directory, rename `config.php.sample` to `config.php` and change the values in that file to something that works for you.
+* If you would like to use the same codebase to host url shortening for more than one domain, you can copy config.php.sample to DOMAIN.EXT-config.php. The code will look for this file before loading the default config.php.
 * Change permissions on `inc/config.php`, `inc/daily-count.txt` and `content/urls` to be writable by the server. Ususally, that involves a `chmod 777` on those files and directories in the terminal.
 * Hit the URL you've uploaded this to in your browser. You should be prompted to set a password, so do so!
 
@@ -109,6 +110,8 @@ If, at any time, you'd like to change your password, it's easy to do. Just take 
 That will write a new `HASHED_PASSWORD` definition to `inc/config.php`. Be sure to update your calls to the **/create** endpoint to use the new password!
 
 ## Version History
+
+**0.1.2** - Added multi-domain support i.e. virtual domains pointing to the same IP.
 
 **0.1.1** - Added a default redirect option. Current stable version.
 

--- a/lib/URLShortener/URLShortener.php
+++ b/lib/URLShortener/URLShortener.php
@@ -57,7 +57,7 @@ require_once(CONFIG_FILE);
 class URLShortener
 {
 
-	private $_version          = '0.1.0';
+	private $_version          = '0.1.2';
 	private $_content_dir      = 'content/';
 	private $_daily_count_file = '';
 	private $_alphabet         = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'; // Alphabet excludes 0, O, I, and l to minimize ambiguious hashes

--- a/lib/URLShortener/URLShortener.php
+++ b/lib/URLShortener/URLShortener.php
@@ -19,17 +19,37 @@
 require_once(realpath(__DIR__ . '/../PasswordHash/PasswordHash.php'));
 require_once(realpath(__DIR__ . '/../Hashids/Hashids.php'));
 
-define('CONFIG_FILE', realpath(__DIR__ . '/../../inc/config.php'));
+define('CONFIG_DIR',  __DIR__ . "/../../inc/");
+
 
 /*
  * Get the config
+ *
+ * Domain config:  DOMAIN.EXT-config.php
+ * DEFAULT config: config.php
  */
-if ( ! file_exists(CONFIG_FILE) ) {
-	die("Can't find the configuration file. Please make sure it is set up.");
+$default_config = realpath(CONFIG_DIR . "config.php");
+$request_uri = $_SERVER['HTTP_HOST'];
+// remove the www
+$www = strrpos($request_uri, "www.");
+if ($www === 0) 
+	$request_uri = substr($request_uri, $www + 4);
+// create the domain file name
+$uri_config = realpath(CONFIG_DIR . $request_uri . '-config.php');
+
+// the domain config is given priority, check if it exists first
+if ( ! file_exists($uri_config) ) {
+	// check for the default config if no domain config is found
+	if ( ! file_exists($default_config) ) {
+		die("Can't find the configuration file. Please make sure it is set up.");
+	} else {
+		define('CONFIG_FILE', $default_config);
+	}
+} else {
+	define('CONFIG_FILE', $uri_config);
 }
+
 require_once(CONFIG_FILE);
-
-
 
 /**
 * URLShortener Class
@@ -37,7 +57,7 @@ require_once(CONFIG_FILE);
 class URLShortener
 {
 
-	private $_version          = '0.1.1';
+	private $_version          = '0.1.0';
 	private $_content_dir      = 'content/';
 	private $_daily_count_file = '';
 	private $_alphabet         = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'; // Alphabet excludes 0, O, I, and l to minimize ambiguious hashes


### PR DESCRIPTION
If you would like to use the same codebase to host url shortening for more than one domain, you can copy config.php.sample to DOMAIN.EXT-config.php. The code will look for this file before loading the default config.php.
